### PR TITLE
Fix small numerical errors using Newton-Raphson

### DIFF
--- a/engine/calculus/CubicFunction.cs
+++ b/engine/calculus/CubicFunction.cs
@@ -17,7 +17,6 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System;
-using System.Security.Cryptography;
 
 namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 {
@@ -79,11 +78,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			DebugUtil.AssertFinite(b, nameof(b));
 			DebugUtil.AssertFinite(c, nameof(c));
 			DebugUtil.AssertFinite(d, nameof(d));
-			if(Math.Abs(a) <= 0.005f)
+			if(Math.Abs(a) <= 0.005)
 			{
 				foreach (double v in QuadraticFunction.Solve(d, c, b))
 				{
-					yield return v;
+					CubicFunction f = new CubicFunction(d, c, b, a);
+					yield return f.NewtonRaphson(v);
 				}
 				yield break;
 			}

--- a/engine/calculus/DerivableFunction.cs
+++ b/engine/calculus/DerivableFunction.cs
@@ -55,4 +55,26 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 		/// </exception>
 		public TOut GetDerivativeAt(TIn x) => GetNthDerivativeAt(x, 1);
 	}
+
+	public static class DerivableFunctionExtensions
+	{
+		private const int DefaultNewtonRaphsonIterations = 16;
+
+		/// <summary>
+		/// Gradually approach the root of a derivable function using the Newton-Raphson iterative numerical method.
+		/// </summary>
+		/// <param name="start">Point at which to start searching for a root. For best results, this starting point must
+		/// be close to the root.</param>
+		public static double NewtonRaphson(this DerivableFunction<double, double> self,
+			double start,
+			int iterations = DefaultNewtonRaphsonIterations)
+		{
+			double x = start;
+			for (int i = 0; i < iterations; i++)
+			{
+				x = x - self.GetValueAt(x) / self.GetDerivativeAt(start);
+			}
+			return x;
+		}
+	}
 }

--- a/engine/calculus/QuadraticFunction.cs
+++ b/engine/calculus/QuadraticFunction.cs
@@ -88,9 +88,12 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 					// There are no roots found:
 					yield break;
 				} else {
-					// There is a single root, found from solving the linear equation with a1=0:
-					yield return -a0/a1;
-					
+					// There is a single root, found from solving the linear equation with a1=0. We find a point close
+					// to the root using the linear approximation, after which we approach the true solution using the
+					// Newton-Raphson method:
+					QuadraticFunction f = new QuadraticFunction(a0, a1, a2);
+					yield return f.NewtonRaphson(-a0 / a1);
+
 				}
 				yield break;
 			}

--- a/engine/calculus/QuarticFunction.cs
+++ b/engine/calculus/QuarticFunction.cs
@@ -28,7 +28,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 	/// \f$q(x) = a_0 + a_1 x + a_2 x^2 + a_3 x^3 + a_4 x^4\f$. See https://en.wikipedia.org/wiki/Quartic_function
 	///	for more information.
 	/// </summary>
-	public class QuarticFunction : ContinuousMap<double, double>
+	public class QuarticFunction : DerivableFunction<double, double>
 	{
 		public double a0 { get; }
 		public double a1 { get; }
@@ -50,7 +50,7 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			this.a4 = a4;
 		}
 		
-		public double GetNthDerivativeAt(double x, uint derivative)
+		public override double GetNthDerivativeAt(double x, uint derivative)
 		{
 			DebugUtil.AssertFinite(x, nameof(x));
 			// Return a different function depending on the derivative level:
@@ -93,7 +93,8 @@ namespace FreedomOfFormFoundation.AnatomyEngine.Calculus
 			{
 				foreach (double v in CubicFunction.Solve(a0, a1, a2, a3))
 				{
-					yield return v;
+					QuarticFunction f = new QuarticFunction(a0, a1, a2, a3, a4);
+					yield return f.NewtonRaphson(v);
 				}
 				yield break;
 			}


### PR DESCRIPTION
The small remaining numerical errors caused by using lower-order
approximations can be fixed by approaching the final solution
iteratively using the Newton-Raphson method. This currently
doesn't have a noticeable performance impact, and solves most
visual artifacts. Of course, we can later optimize this further.